### PR TITLE
now it receives a '/cursos/' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Este proyecto te ayuda a saber cuánto tiempo dura cualquier curso de Platzi, es
 Clona el proyecto, entra al directorio y ejecuta el comando `npm install` 
 
 ## Uso 
-1) Debes estar logueado en platzi para poder acceder a los contenidos de los cursos. 
-2) Copiar la URL del curso que quieres saber la duración **la URL debe tener la lista de clases del curso como se muestra en la imagen inferior**
+
+1) Copiar la URL del curso que quieres saber la duración **la URL debe tener la lista de clases del curso como se muestra en la imagen inferior**
 ![Imgur](https://i.imgur.com/eLRe0cF.png)
 
-3) En la terminal ejecutar el comando `npm run start` 
-4) El programa te pedirá la URL del curso, solo tienes que pegarla como se muestra en la imagen inferior. 
+2) En la terminal ejecutar el comando `npm run start` 
+3) El programa te pedirá la URL del curso, solo tienes que pegarla como se muestra en la imagen inferior. 
 ![Imgur](https://i.imgur.com/dvh9Djm.png)
 Esperas un poco y listo tendrás la duración del curso 
 ![Imgur](https://i.imgur.com/9lAwtgm.png)

--- a/src/handleRequest.js
+++ b/src/handleRequest.js
@@ -2,12 +2,16 @@ const puppeteer = require('puppeteer');
 const moment = require('moment');
 
 const handleRequest = async platziCourseUrl => {
+
+  const course_name = platziCourseUrl.substr(26,);
+
   const browser = await puppeteer.launch({
     headless: true,
     defaultViewport: null
   });
   const page = await browser.newPage();
-  await page.goto(platziCourseUrl);
+  const URL = `https://platzi.com/clases/${course_name}`
+  await page.goto(URL);
   const classes = await page.evaluate(async () => {
     const prefix = 'MaterialItem';
     const content = `${prefix}-content`;


### PR DESCRIPTION
antes la persona tenía que estar logeado dentro de platzi para buscar el link correcto de los cursos, ahora no lo necesita, puede introducir el link que le da platzi cuando se está buscando un curso sin necesidad de logearse